### PR TITLE
Update jate to be able to work with Solr 6.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,8 @@
         <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
 		<maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
         <exec-maven-plugin.version>1.4.0</exec-maven-plugin.version>
-        <tika.version>1.10</tika.version>
-        <solr.version>5.3.0</solr.version>
+        <tika.version>1.15</tika.version>
+        <solr.version>6.6.0</solr.version>
         <matrix-toolkits-java.version>1.0.5-SNAPSHOT</matrix-toolkits-java.version>
         <opennlp-tools.version>1.6.0</opennlp-tools.version>
         <dragontool.version>1.3.3</dragontool.version>
@@ -92,6 +92,8 @@
             <groupId>edu.drexel</groupId>
             <artifactId>dragontool</artifactId>
             <version>${dragontool.version}</version>
+            <scope>system</scope>
+            <systemPath>${basedir}/lib/dragontool.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>org.apache.solr</groupId>

--- a/src/main/java/uk/ac/shef/dcs/jate/algorithm/RAKEWorker.java
+++ b/src/main/java/uk/ac/shef/dcs/jate/algorithm/RAKEWorker.java
@@ -73,8 +73,8 @@ public class RAKEWorker extends JATERecursiveTaskWorker<String, List<JATETerm>> 
                 //for the remaining part of degree, it depends on terms (parent term) that contain this element
                 List<Pair<String, Integer>> parentTerms=fTermCompIndex.getSorted(e);
                 for(Pair<String, Integer> pTerm: parentTerms){
-                    String pTermStr = pTerm.getKey();
-                    if(pTerm.getValue()==1) //we are only interested in multi-word expressions for computing degree
+                    String pTermStr = pTerm.first();
+                    if(pTerm.second()==1) //we are only interested in multi-word expressions for computing degree
                         continue;
 
                     int pTF = fFeatureTerms.getTTF(pTermStr); //how many times this parent term appear in corpus

--- a/src/main/java/uk/ac/shef/dcs/jate/algorithm/TermInfoCollector.java
+++ b/src/main/java/uk/ac/shef/dcs/jate/algorithm/TermInfoCollector.java
@@ -12,11 +12,11 @@ import java.util.Set;
 
 public class TermInfoCollector {
 
-    protected LeafReader indexReader;
+    protected IndexReader indexReader;
     protected String ngramInfoFieldname;
     protected String idFieldname;
 
-    public TermInfoCollector(LeafReader indexReader, String ngramInfoFieldname,
+    public TermInfoCollector(IndexReader indexReader, String ngramInfoFieldname,
                              String idFieldname) {
         this.indexReader = indexReader;
         this.ngramInfoFieldname=ngramInfoFieldname;

--- a/src/main/java/uk/ac/shef/dcs/jate/app/App.java
+++ b/src/main/java/uk/ac/shef/dcs/jate/app/App.java
@@ -3,6 +3,7 @@ package uk.ac.shef.dcs.jate.app;
 import com.google.gson.Gson;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReader;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
@@ -451,7 +452,7 @@ public abstract class App {
                                       String idField) throws JATEException {
         if (this.collectTermInfo) {
             try {
-                collectTermOffsets(terms, searcher.getLeafReader(), content2NgramField, idField);
+                collectTermOffsets(terms, searcher.getSlowAtomicReader(), content2NgramField, idField);
             } catch (IOException e) {
                 throw new JATEException("I/O exception when reading Solr index. " + e.toString());
             }

--- a/src/main/java/uk/ac/shef/dcs/jate/app/Voting.java
+++ b/src/main/java/uk/ac/shef/dcs/jate/app/Voting.java
@@ -99,10 +99,10 @@ public class Voting {
 
         for (Pair result : algResultWithWeight) {
             Pair<List<JATETerm>, Double> pair = (Pair<List<JATETerm>, Double>) result;
-            for (int i = 0; i < pair.getKey().size(); i++) {
-                JATETerm jt = pair.getKey().get(i);
+            for (int i = 0; i < pair.first().size(); i++) {
+                JATETerm jt = pair.first().get(i);
                 String termStr = jt.getString();
-                double rankScore = 1.0 / (i + 1) * pair.getValue();
+                double rankScore = 1.0 / (i + 1) * pair.second();
                 Double finalScore = voteScores.get(termStr);
                 if (finalScore == null)
                     finalScore = 0.0;

--- a/src/main/java/uk/ac/shef/dcs/jate/feature/ContainmentFBWorker.java
+++ b/src/main/java/uk/ac/shef/dcs/jate/feature/ContainmentFBWorker.java
@@ -56,9 +56,9 @@ class ContainmentFBWorker extends JATERecursiveTaskWorker<String, int[]> {
                 Iterator<Pair<String, Integer>> it = candidates.iterator();
                 while (it.hasNext()) {
                     Pair<String, Integer> c = it.next();
-                    if (c.getValue() <= tokens.length)
+                    if (c.second() <= tokens.length)
                         break;
-                    compareCandidates.add(c.getKey());
+                    compareCandidates.add(c.first());
                 }
 
             }

--- a/src/main/java/uk/ac/shef/dcs/jate/feature/TermComponentIndex.java
+++ b/src/main/java/uk/ac/shef/dcs/jate/feature/TermComponentIndex.java
@@ -27,7 +27,7 @@ public class TermComponentIndex extends AbstractFeature {
         if (values!=null)
             sorted.addAll(values);
 
-        Collections.sort(sorted, (o1, o2) -> o2.getValue().compareTo(o1.getValue()));
+        Collections.sort(sorted, (o1, o2) -> o2.first().compareTo(String.valueOf(o1.second())));
         return sorted;
     }
 }

--- a/src/main/java/uk/ac/shef/dcs/jate/solr/TermRecognitionRequestHandler.java
+++ b/src/main/java/uk/ac/shef/dcs/jate/solr/TermRecognitionRequestHandler.java
@@ -429,10 +429,10 @@ public class TermRecognitionRequestHandler extends RequestHandlerBase {
             }
 
             if (isBoosted) {
-                doc.add(indexSchema.getField(domainTermsFieldName).createField(filteredTerm.getKey(),
-                        filteredTerm.getValue().floatValue()));
+                doc.add(indexSchema.getField(domainTermsFieldName).createField(filteredTerm.first(),
+                        filteredTerm.second().floatValue()));
             } else {
-                doc.add(indexSchema.getField(domainTermsFieldName).createField(filteredTerm.getKey(),
+                doc.add(indexSchema.getField(domainTermsFieldName).createField(filteredTerm.first(),
                         DEFAULT_BOOST_VALUE));
             }
         }

--- a/src/main/java/uk/ac/shef/dcs/jate/util/SolrUtil.java
+++ b/src/main/java/uk/ac/shef/dcs/jate/util/SolrUtil.java
@@ -29,7 +29,7 @@ public class SolrUtil {
      */
     public static Terms getTermVector(String fieldname, SolrIndexSearcher solrIndexSearcher) throws JATEException {
         try {
-            Fields fields = MultiFields.getFields(solrIndexSearcher.getLeafReader());
+            Fields fields = MultiFields.getFields(solrIndexSearcher.getSlowAtomicReader());
 
             Terms vector = fields.terms(fieldname);
             if (vector == null)
@@ -79,7 +79,7 @@ public class SolrUtil {
 
     public static Terms getTermVector(int docId, String fieldname, SolrIndexSearcher solrIndexSearcher) throws JATEException {
         try {
-            Terms vector = solrIndexSearcher.getLeafReader().getTermVector(docId, fieldname);
+            Terms vector = solrIndexSearcher.getSlowAtomicReader().getTermVector(docId, fieldname);
 
             return vector;
         } catch (IOException ioe) {

--- a/testdata/solr-testbed/ACLRDTEC/conf/solrconfig.xml
+++ b/testdata/solr-testbed/ACLRDTEC/conf/solrconfig.xml
@@ -340,7 +340,6 @@
         reduce the risk of propagating index corruption from older segments 
         into new ones, at the expense of slower merging.
     -->
-     <checkIntegrityAtMerge>false</checkIntegrityAtMerge>
   </indexConfig>
 
 

--- a/testdata/solr-testbed/GENIA/conf/solrconfig.xml
+++ b/testdata/solr-testbed/GENIA/conf/solrconfig.xml
@@ -340,7 +340,6 @@
         reduce the risk of propagating index corruption from older segments 
         into new ones, at the expense of slower merging.
     -->
-     <checkIntegrityAtMerge>false</checkIntegrityAtMerge>
   </indexConfig>
 
 

--- a/testdata/solr-testbed/scienceie_test/conf/solrconfig.xml
+++ b/testdata/solr-testbed/scienceie_test/conf/solrconfig.xml
@@ -340,7 +340,6 @@
         reduce the risk of propagating index corruption from older segments 
         into new ones, at the expense of slower merging.
     -->
-     <checkIntegrityAtMerge>false</checkIntegrityAtMerge>
   </indexConfig>
 
 

--- a/testdata/solr-testbed/ttc_mobile/conf/solrconfig.xml
+++ b/testdata/solr-testbed/ttc_mobile/conf/solrconfig.xml
@@ -340,7 +340,6 @@
         reduce the risk of propagating index corruption from older segments 
         into new ones, at the expense of slower merging.
     -->
-     <checkIntegrityAtMerge>false</checkIntegrityAtMerge>
   </indexConfig>
 
 

--- a/testdata/solr-testbed/ttc_wind/conf/solrconfig.xml
+++ b/testdata/solr-testbed/ttc_wind/conf/solrconfig.xml
@@ -340,7 +340,6 @@
         reduce the risk of propagating index corruption from older segments 
         into new ones, at the expense of slower merging.
     -->
-     <checkIntegrityAtMerge>false</checkIntegrityAtMerge>
   </indexConfig>
 
 


### PR DESCRIPTION
0. Solr version is upgraded to 6.6, Tika version to 1.15
1. SolrJ API updated (first, second in pairs instead of key, value)
2. there is no more getLeafReader -> replaced with getSlowAtomicReader which provides same LeafReader