### PR TITLE
Switched to use `dragontool` from `de.julielab`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
             <version>${opennlp-tools.version}</version>
         </dependency>
         <dependency>
-            <groupId>edu.drexel</groupId>
+            <groupId>de.julielab</groupId>
             <artifactId>dragontool</artifactId>
             <version>${dragontool.version}</version>
         </dependency>


### PR DESCRIPTION
Used version of `dragontool` from `edu.drexel` doesn't exist at maven central anymore. But the same version exists at `de.julielab` and works fine.