### PR TITLE
feat: JATE v3.0.0 — Python rewrite with 14 ATE algorithms

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: '^docs/'
 default_stages: [pre-commit]
 
 default_language_version:
-  python: python3.11
+  python: python3.12
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -23,7 +23,7 @@ repos:
     rev: 24.8.0
     hooks:
       - id: black
-        language_version: python3.11
+        language_version: python3.12
 
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2


### PR DESCRIPTION
## Summary

Complete rewrite of JATE from Java/Solr to a pure-Python, pip-installable library.

- **14 ATE algorithms**: TFIDF, C-Value, NC-Value, Basic, ComboBasic, ATTF, TTF, RIDF, RAKE, Chi-Square, Weirdness, TermEx, GlossEx, and Voting (ensemble via reciprocal rank fusion)
- **9 feature classes** mirroring Java JATE's feature system: TermFrequency, WordFrequency, ReferenceFrequency, ContextFrequency, ContextWindow, TermComponentIndex, Containment, Cooccurrence, ChiSquareFrequentTerms — all formulas verified line-by-line against the Java source
- **3 candidate extractors**: POS pattern, n-gram, noun phrase
- **Lemmatisation-aware pipeline** with surface form tracking
- **In-memory and SQLite-backed** corpus statistics stores
- **Built-in evaluation** (P/R/F1) against gold standard term lists
- **Benchmark runner** with ACL RD-TEC Mini built-in dataset
- **CLI** with extract, corpus, compare, benchmark commands
- **Configurable parallelism** via `JATEConfig(max_workers=N)`
- **External reference corpus support** for Weirdness, GlossEx, TermEx
- **257 tests passing**, comprehensive documentation via mkdocs

## Key changes from Java JATE

- No longer requires Apache Solr — corpus statistics are self-contained
- Python 3.11+ required
- spaCy-based NLP backend with Protocol interface for extensibility
- Export to pandas DataFrame, CSV, JSON

## Test plan

- [ ] CI passes: lint (black, isort, flake8), type check (mypy), tests (Python 3.11 + 3.12)
- [ ] Package builds and installs correctly
- [ ] Semantic release creates v3.0.0 tag
- [ ] PyPI publish triggers on release

🤖 Generated with [Claude Code](https://claude.com/claude-code)