### PR TITLE
docs: update README with v3.0.0 intro and contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Python library for automatic term extraction (ATE) from text corpora. JATE provides 14 ATE algorithms (13 classical + ensemble voting), corpus-level statistics, built-in evaluation, and a CLI — all pip-installable with no external services required.
 
-> Previously known as "Java Automatic Term Extraction" (84+ stars). The original Java/Solr library is preserved on the [`legacy/java`](https://github.com/ziqizhang/jate/tree/legacy/java) branch.
+**JATE v3.0.0** is a complete rewrite of the original [Java JATE](https://github.com/ziqizhang/jate/tree/legacy/java) library (84+ GitHub stars), which was built on Apache Solr and used in academic and industry settings for over a decade. The Python version preserves all 13 classical algorithms from the Java codebase — with every formula verified line-by-line against the original source — while removing the Solr dependency in favour of a self-contained, pip-installable package. The original Java library is preserved on the [`legacy/java`](https://github.com/ziqizhang/jate/tree/legacy/java) branch.
 
 ## Installation
 
@@ -154,24 +154,17 @@ Each `Term` in the result contains:
 - `frequency` — total corpus frequency
 - `surface_forms` — all surface variants observed (e.g. `{"neural network", "neural networks", "Neural Networks"}`)
 
-## Roadmap
+## Contributing
 
-- **spaCy pipeline integration** — `nlp.add_pipe("jate")`
-- **Interactive web demo** — Streamlit UI with HuggingFace Spaces deployment
-- **More benchmarks** — ACTER, GENIA, CoastTerm, TermEval datasets
-- **Neural methods** — BERT-based sequence labeling, embedding-based scoring
-- **LLM-augmented extraction** — optional LLM re-ranking and validation
-- **Agentic pipeline** — LangGraph-powered orchestration for automatic algorithm selection
-- **Multilingual support** — works with any spaCy language model
-- **Production-ready** — strict typing, >90% test coverage, Docker, PyPI publishing
+JATE is in active development and we welcome contributions. Here's how you can get involved:
 
-## Get involved
-
-JATE is in active development. We'd love your input:
-
-- **Feature requests:** [Open an issue](https://github.com/ziqizhang/jate/issues/new?template=feature_request.yml)
-- **Bug reports:** [Report here](https://github.com/ziqizhang/jate/issues/new?template=bug_report.yml)
+- **Browse open issues** — check the [feature roadmap](https://github.com/ziqizhang/jate/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) for planned enhancements
+- **Good first issues** — look for issues labelled [`good first issue`](https://github.com/ziqizhang/jate/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) if you're new to the project
+- **Feature requests** — [open an issue](https://github.com/ziqizhang/jate/issues/new?template=feature_request.yml) to suggest new features
+- **Bug reports** — [report here](https://github.com/ziqizhang/jate/issues/new?template=bug_report.yml)
 - **Star the repo** to follow progress
+
+See [CONTRIBUTING.md](docs/contributing.md) for development setup and guidelines.
 
 ## Background
 
@@ -186,5 +179,3 @@ JATE was originally developed as part of research at the University of Sheffield
 Apache 2.0 — see [LICENSE](LICENSE) for details.
 
 ---
-
-*Built with research expertise and agentic coding tools.*


### PR DESCRIPTION
## Summary

- Added explanation at top of README that v3.0.0 is a complete rewrite of the Java JATE library
- Replaced roadmap section with contributing section pointing to GitHub issues
- Removed "built with agentic coding tools" footer