### PR TITLE
feat: add official Docker image for JATE

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.github
+tests
+docs
+__pycache__
+*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# -------- Builder stage --------
+FROM python:3.11-slim AS builder
+
+WORKDIR /app
+
+RUN pip install --upgrade pip
+
+# install package
+RUN pip install jate spacy
+
+# install spaCy model required by README
+RUN python -m spacy download en_core_web_sm
+
+
+# -------- Runtime stage --------
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY --from=builder /usr/local /usr/local
+
+ENTRYPOINT ["jate"]


### PR DESCRIPTION
### Summary

This PR adds an official Docker image for running JATE without requiring a local Python installation.

### Features

* Multi-stage Docker build
* Pre-installed spaCy `en_core_web_sm` model
* CLI exposed via `ENTRYPOINT`
* Small runtime image

### Usage

Build image:

```
docker build -t jate .
```

Run extraction:

```
docker run jate extract "Natural language processing is amazing" --algorithm cvalue
```

### Motivation

This simplifies running JATE in containerized environments, CI pipelines, and cloud platforms where installing Python dependencies manually may be inconvenient.
